### PR TITLE
[WIP]Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,11 @@
-# README
+## groups_usersテーブル
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
-Things you may want to cover:
+### Association
+- belongs_to :group
+- belongs_to :user## groups_usersテーブル
 
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...

--- a/README.md
+++ b/README.md
@@ -9,3 +9,37 @@
 - belongs_to :group
 - belongs_to :user## groups_usersテーブル
 
+## userテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|index:true,null:false|
+|mail|string|null:false|
+|password|string|null:false,index:true|
+|id|integer|null:false|
+
+### Association
+- has_many :tweet
+- has_many :group, through: :groups_users
+
+## groupテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|index:true,null:false|
+|id|integer|null:false|
+
+### Association
+- has_many :user, through: :groupes_users
+
+
+
+## Tweetテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null:false,|
+|id|integer|null:false|
+|image|||
+
+### Association
+belongs_to :user

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
 - belongs_to :user## groups_usersテーブル
 
-## userテーブル
+## usersテーブル
 
 |Column|Type|Options|
 |------|----|-------|
@@ -19,8 +19,9 @@
 |id|integer|null:false|
 
 ### Association
-- has_many :tweet
+- has_many :tweets ,
 - has_many :group, through: :groups_users
+- has_many :groups_users
 
 ## groupテーブル
 
@@ -31,15 +32,20 @@
 
 ### Association
 - has_many :user, through: :groupes_users
+- has_many :tweets
+- has_many :group_users
 
 
 
 ## Tweetテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null:false,|
+|user_id|references|index:true,null:false|
+|group_id|references|index:true,null:false|
 |id|integer|null:false|
+|text|string||
 |image|||
 
 ### Association
-belongs_to :user
+- belongs_to :user
+- belongs_to :group


### PR DESCRIPTION
#What
READMEにグループとユーザーの中間テーブルに当たるgroups_usersテーブルを記載する。
#Why
多対多の関係をもつテーブル同士をアソシエーションするためには中間テーブルが必要だから。
